### PR TITLE
chore: use GitHub team to identify PRs from team members

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -65,7 +65,7 @@ pull_request_rules:
       label:
         add: [contribution/core]
     conditions:
-      - author~=^(rix0rrr|iliapolo|otaviomacedo|kaizencc|TheRealAmazonKendra|mrgrain|pahud|ashishdhingra|kellertk|moelasmar|paulhcsun|GavinZZ|xazhao|gracelu0|shikha372|QuantumNeuralCoder|godwingrs22|bergjaak|samson-keung|IanKonlog|Leo10Gama|scorbiere|jiayiwang7|saiyush|5d|iankhou|SimonCMoore|maharajhaider|Y-JayKim|astiwana|ykethan|aemada-aws|ozelalisen|abogical|alinko-aws|vishaalmehrishi|alvazjor|kumsmrit|kumvprat|leonmk-aws|matboros|gasolima)$
+      - author=@aws/aws-cdk-team
       - -label~="contribution/core"
   - name: automatic merge
     actions:


### PR DESCRIPTION
This removes the need to keep this config up to date.

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
