### PR TITLE
[Test PR] Verify security-guardian runs from base branch

### DIFF
--- a/.github/workflows/security-guardian.yml
+++ b/.github/workflows/security-guardian.yml
@@ -20,12 +20,15 @@ jobs:
       !startsWith(github.event.pull_request.title, 'chore(release):') &&
       !startsWith(github.event.pull_request.title, 'chore(merge-back):')
     runs-on: ubuntu-latest
-    steps:      
-      - name: Checkout
+    steps:
+      - name: Checkout base branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0  
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0
+
+      - name: Fetch PR head commit
+        run: git fetch origin +refs/pull/${{ github.event.pull_request.number }}/head:refs/heads/pr-head
 
       - name: Install cfn-guard
         run: |
@@ -46,12 +49,7 @@ jobs:
           base_sha: ${{ github.event.pull_request.base.sha }}
           head_sha: ${{ github.event.pull_request.head.sha }}
           rule_set_path: './tools/@aws-cdk/security-guardian/rules'
-      - name: Save PR info for security-report
-        if: always()
-        run: |
-          echo "${{ github.event.pull_request.number }}" > ./test-results/pr_number
-          echo "${{ github.event.pull_request.head.sha }}" > ./test-results/pr_sha
-      
+
       - name: Upload Security Guardian XML Reports
         uses: actions/upload-artifact@v7
         if: always()

--- a/packages/@aws-cdk-testing/framework-integ/test/aws-lambda/test/integ.runtime.inlinecode.js.snapshot/aws-cdk-lambda-runtime-inlinecode.template.json
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-lambda/test/integ.runtime.inlinecode.js.snapshot/aws-cdk-lambda-runtime-inlinecode.template.json
@@ -1,4 +1,5 @@
 {
+ "Description": "dummy change to trigger workflow validation",
  "Resources": {
   "PYTHON38ServiceRole3EA86BBE": {
    "Type": "AWS::IAM::Role",


### PR DESCRIPTION
Test-only PR to validate the refactored security-guardian workflow.

**Changes:**
- `.github/workflows/security-guardian.yml`: check out base branch and fetch PR head into a local ref; drop the "Save PR info" step
- One `.js.snapshot` template gets a dummy `Description` field to trigger the path filter

**What to verify:**
1. Workflow runs (path filter matches)
2. Scanner runs from base-branch working tree (yarn install / tool build from main)
3. Scanner still detects the changed template via `git show pr_head_sha:<file>`
4. Artifact uploads with the cfn-guard XMLs

Not for merge.