### PR TITLE
[Test PR] Trigger security-guardian workflow chain

### DIFF
--- a/.github/workflows/security-guardian.yml
+++ b/.github/workflows/security-guardian.yml
@@ -20,12 +20,15 @@ jobs:
       !startsWith(github.event.pull_request.title, 'chore(release):') &&
       !startsWith(github.event.pull_request.title, 'chore(merge-back):')
     runs-on: ubuntu-latest
-    steps:      
-      - name: Checkout
+    steps:
+      - name: Checkout base branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0  
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0
+
+      - name: Fetch PR head commit
+        run: git fetch origin +refs/pull/${{ github.event.pull_request.number }}/head:refs/heads/pr-head
 
       - name: Install cfn-guard
         run: |
@@ -46,12 +49,7 @@ jobs:
           base_sha: ${{ github.event.pull_request.base.sha }}
           head_sha: ${{ github.event.pull_request.head.sha }}
           rule_set_path: './tools/@aws-cdk/security-guardian/rules'
-      - name: Save PR info for security-report
-        if: always()
-        run: |
-          echo "${{ github.event.pull_request.number }}" > ./test-results/pr_number
-          echo "${{ github.event.pull_request.head.sha }}" > ./test-results/pr_sha
-      
+
       - name: Upload Security Guardian XML Reports
         uses: actions/upload-artifact@v7
         if: always()

--- a/.github/workflows/security-guardian.yml
+++ b/.github/workflows/security-guardian.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch PR head commit
-        run: git fetch origin +refs/pull/${{ github.event.pull_request.number }}/head:refs/heads/pr-head
+        run: git fetch origin ${{ github.event.pull_request.head.sha }}
 
       - name: Install cfn-guard
         run: |

--- a/.github/workflows/security-report.yml
+++ b/.github/workflows/security-report.yml
@@ -4,6 +4,10 @@ on:
     workflows: ["Security Guardian"]
     types: [completed]
 
+concurrency:
+  group: security-report-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -19,7 +23,12 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const forkOwner = context.payload.workflow_run.head_repository.owner.login;
+            const headRepo = context.payload.workflow_run.head_repository;
+            if (!headRepo || !headRepo.owner || !headRepo.owner.login) {
+              core.setFailed('workflow_run.head_repository is missing (fork deleted?)');
+              return;
+            }
+            const forkOwner = headRepo.owner.login;
             const branch    = context.payload.workflow_run.head_branch;
             const headSha   = context.payload.workflow_run.head_sha;
 
@@ -44,7 +53,8 @@ jobs:
               repo:  context.repo.repo,
               pull_number: pr.number,
             });
-            if (files.some(f => f.filename === '.github/workflows/security-guardian.yml')) {
+            const target = '.github/workflows/security-guardian.yml';
+            if (files.some(f => f.filename === target || f.previous_filename === target)) {
               core.setFailed('PR modifies security-guardian workflow');
               return;
             }

--- a/.github/workflows/security-report.yml
+++ b/.github/workflows/security-report.yml
@@ -5,7 +5,55 @@ on:
     types: [completed]
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      actions: read
+    outputs:
+      pr_number: ${{ steps.check.outputs.pr_number }}
+      pr_sha: ${{ steps.check.outputs.pr_sha }}
+    steps:
+      - name: Resolve PR and check diff
+        id: check
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const forkOwner = context.payload.workflow_run.head_repository.owner.login;
+            const branch    = context.payload.workflow_run.head_branch;
+            const headSha   = context.payload.workflow_run.head_sha;
+
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              state: 'open',
+              head:  `${forkOwner}:${branch}`,
+            });
+            if (prs.length !== 1) {
+              core.setFailed(`Expected 1 PR, got ${prs.length}`);
+              return;
+            }
+            const pr = prs[0];
+            if (pr.head.sha !== headSha) {
+              core.setFailed(`SHA mismatch: expected ${headSha}, got ${pr.head.sha}`);
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              pull_number: pr.number,
+            });
+            if (files.some(f => f.filename === '.github/workflows/security-guardian.yml')) {
+              core.setFailed('PR modifies security-guardian workflow');
+              return;
+            }
+
+            core.setOutput('pr_number', pr.number);
+            core.setOutput('pr_sha',    headSha);
+
   report:
+    needs: validate
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -23,14 +71,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
           repository: ${{ github.repository }}
-      
-      - name: Get PR info
-        id: pr_info
-        run: |
-          echo "pr_number=$(cat test-results/pr_number)" >> "$GITHUB_OUTPUT"
-          echo "pr_sha=$(cat test-results/pr_sha)" >> "$GITHUB_OUTPUT"
-          echo "PR: $(cat test-results/pr_number), SHA: $(cat test-results/pr_sha)"
-      - name: Publish Security Test Results 
+
+      - name: Publish Security Test Results
         id: junit_static
         uses: mikepenz/action-junit-report@v6
         if: always()
@@ -38,10 +80,10 @@ jobs:
           report_paths: 'test-results/**/cfn-guard-static.xml'
           check_name: ${{ env.CHECK_NAME_STATIC }}
           exclude_sources: 'node_modules,dist'
-          commit: ${{ steps.pr_info.outputs.pr_sha }}
+          commit: ${{ needs.validate.outputs.pr_sha }}
           check_annotations: true
           comment: true
-          pr_id: ${{ steps.pr_info.outputs.pr_number }}
+          pr_id: ${{ needs.validate.outputs.pr_number }}
           detailed_summary: true
           include_passed: false
           fail_on_failure: false
@@ -54,7 +96,7 @@ jobs:
         uses: actions/github-script@v9
         if: steps.junit_static.outcome == 'success'
         env:
-          PR_NUMBER: ${{ steps.pr_info.outputs.pr_number }}
+          PR_NUMBER: ${{ needs.validate.outputs.pr_number }}
           CHECK_NAME: ${{ env.CHECK_NAME_STATIC }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -66,13 +108,13 @@ jobs:
               repo: context.repo.repo,
               issue_number: prNumber,
             });
-            
-            const botComment = comments.data.find(comment => 
-              comment.user.type === 'Bot' && 
+
+            const botComment = comments.data.find(comment =>
+              comment.user.type === 'Bot' &&
               comment.body.includes(checkName) &&
               !comment.body.includes('resolved templates')
             );
-            
+
             if (botComment) {
               const disclaimer = '⚠️ **Experimental Feature**: This security report is currently in experimental phase. Results may include false positives and the rules are being actively refined. \n**This security report is NOT a review blocker.** Please try `merge from main` to avoid findings unrelated to the PR.\nTo suppress a specific rule, see [Suppressing Rules](https://github.com/aws/aws-cdk/blob/main/tools/%40aws-cdk/security-guardian/README.md#suppressing-rules).\n\n---\n\n';
               await github.rest.issues.updateComment({
@@ -91,10 +133,10 @@ jobs:
           report_paths: 'test-results/**/cfn-guard-resolved.xml'
           check_name: ${{ env.CHECK_NAME_RESOLVED }}
           exclude_sources: 'node_modules,dist'
-          commit: ${{ steps.pr_info.outputs.pr_sha }}
+          commit: ${{ needs.validate.outputs.pr_sha }}
           check_annotations: true
           comment: true
-          pr_id: ${{ steps.pr_info.outputs.pr_number }}
+          pr_id: ${{ needs.validate.outputs.pr_number }}
           detailed_summary: true
           include_passed: false
           fail_on_failure: false
@@ -107,7 +149,7 @@ jobs:
         uses: actions/github-script@v9
         if: steps.junit_resolved.outcome == 'success'
         env:
-          PR_NUMBER: ${{ steps.pr_info.outputs.pr_number }}
+          PR_NUMBER: ${{ needs.validate.outputs.pr_number }}
           CHECK_NAME: ${{ env.CHECK_NAME_RESOLVED }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -119,12 +161,12 @@ jobs:
               repo: context.repo.repo,
               issue_number: prNumber,
             });
-            
-            const botComment = comments.data.find(comment => 
-              comment.user.type === 'Bot' && 
+
+            const botComment = comments.data.find(comment =>
+              comment.user.type === 'Bot' &&
               comment.body.includes(checkName)
             );
-            
+
             if (botComment) {
               const disclaimer = '⚠️ **Experimental Feature**: This security report is currently in experimental phase. Results may include false positives and the rules are being actively refined. \n**This security report is NOT a review blocker.** Please try `merge from main` to avoid findings unrelated to the PR.\nTo suppress a specific rule, see [Suppressing Rules](https://github.com/aws/aws-cdk/blob/main/tools/%40aws-cdk/security-guardian/README.md#suppressing-rules).\n\n---\n\n';
               await github.rest.issues.updateComment({

--- a/.github/workflows/security-report.yml
+++ b/.github/workflows/security-report.yml
@@ -25,18 +25,18 @@ jobs:
           script: |
             const headRepo = context.payload.workflow_run.head_repository;
             if (!headRepo || !headRepo.owner || !headRepo.owner.login) {
-              core.setFailed('workflow_run.head_repository is missing (fork deleted?)');
+              core.setFailed('workflow_run repository information not found');
               return;
             }
-            const forkOwner = headRepo.owner.login;
-            const branch    = context.payload.workflow_run.head_branch;
-            const headSha   = context.payload.workflow_run.head_sha;
+            const owner   = headRepo.owner.login;
+            const branch  = context.payload.workflow_run.head_branch;
+            const headSha = context.payload.workflow_run.head_sha;
 
             const { data: prs } = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo:  context.repo.repo,
               state: 'open',
-              head:  `${forkOwner}:${branch}`,
+              head:  `${owner}:${branch}`,
             });
             if (prs.length !== 1) {
               core.setFailed(`Expected 1 PR, got ${prs.length}`);
@@ -84,7 +84,7 @@ jobs:
 
       - name: Publish Security Test Results
         id: junit_static
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@a9170d5795813c01ab4901ffb045b52bab4ab09d  # v6.5.0
         if: always()
         with:
           report_paths: 'test-results/**/cfn-guard-static.xml'
@@ -137,7 +137,7 @@ jobs:
 
       - name: Publish Security Test Results for resolved templates
         id: junit_resolved
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@a9170d5795813c01ab4901ffb045b52bab4ab09d  # v6.5.0
         if: always()
         with:
           report_paths: 'test-results/**/cfn-guard-resolved.xml'

--- a/packages/@aws-cdk-testing/framework-integ/test/aws-lambda/test/integ.runtime.inlinecode.js.snapshot/aws-cdk-lambda-runtime-inlinecode.template.json
+++ b/packages/@aws-cdk-testing/framework-integ/test/aws-lambda/test/integ.runtime.inlinecode.js.snapshot/aws-cdk-lambda-runtime-inlinecode.template.json
@@ -1,4 +1,5 @@
 {
+ "Description": "dummy change to trigger workflow validation",
  "Resources": {
   "PYTHON38ServiceRole3EA86BBE": {
    "Type": "AWS::IAM::Role",


### PR DESCRIPTION
Fresh test PR after main was updated with the workflow refactor.

**Changes:** dummy Description field on one snapshot template to satisfy the `**.js.snapshot**` path filter.

**What to watch:**
1. `Security Guardian` workflow runs and produces `security-guardian-reports` artifact
2. `Security Report` `validate` job resolves this PR via the API
3. `Security Report` `report` job posts a check run and comment on this PR

Not for merge.